### PR TITLE
Fix isProtectedGroup check

### DIFF
--- a/context/supabase-provider.tsx
+++ b/context/supabase-provider.tsx
@@ -80,10 +80,10 @@ export const SupabaseProvider = ({ children }: SupabaseProviderProps) => {
 	useEffect(() => {
 		if (!initialized) return;
 
-		const inProtectedGroup = segments[0] === "(protected)";
+		const inProtectedGroup = segments[1] === "(protected)";
 
 		if (session && !inProtectedGroup) {
-			router.replace("/(app)/(protected)/");
+			router.replace("/(app)/(protected)");
 		} else if (!session) {
 			router.replace("/(app)/welcome");
 		}


### PR DESCRIPTION
Segments show the full path, example: `/(app)/(protected)`. Therefore to check for a protected segment, the correct index to check is 1. 

Additionally fixes a typescript check by using `/(app)/(protected)` instead of `/(app)/(protected)/`