### PR TITLE
Prevent header overlap on Android

### DIFF
--- a/app/(public)/_layout.tsx
+++ b/app/(public)/_layout.tsx
@@ -1,4 +1,5 @@
 import { Stack } from "expo-router";
+import { Platform } from "react-native";
 
 export default function PublicLayout() {
   return (
@@ -7,14 +8,14 @@ export default function PublicLayout() {
         name="welcome"
         options={{
           title: "Welcome",
-          headerTransparent: true,
+          headerTransparent: Platform.OS === "ios",
         }}
       />
       <Stack.Screen
         name="sign-up"
         options={{
           title: "Sign Up",
-          headerTransparent: true,
+          headerTransparent: Platform.OS === "ios",
           headerLargeTitle: true,
           headerBackButtonDisplayMode: "minimal",
         }}
@@ -23,7 +24,7 @@ export default function PublicLayout() {
         name="sign-in"
         options={{
           title: "Sign In",
-          headerTransparent: true,
+          headerTransparent: Platform.OS === "ios",
           headerLargeTitle: true,
           headerBackButtonDisplayMode: "minimal",
         }}


### PR DESCRIPTION
## Pull Request Template

### Description

Prevent Android header overlap by making stack headers transparent only on iOS.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (code changes that neither fix a bug nor add a feature)
- [ ] Performance improvement
- [ ] Security enhancement
- [ ] Other (please specify):

### Changes Made

- Change 1: Set `headerTransparent` to `Platform.OS === "ios"` for the public stack screens.

### Testing Instructions

1. `npx expo run:android --device`
2. `npx expo run:ios`

### Screenshots (if applicable)

[android-ui-bug-demo.webm](https://github.com/user-attachments/assets/f3070748-911b-43b7-a82d-e96c0748b921)


### Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the project's coding standards
- [ ] I have added/updated tests for my changes
- [x] All tests pass locally
- [ ] I have updated documentation if necessary
- [x] This PR does not introduce any breaking changes
- [ ] I have tested this on multiple devices/platforms (if applicable)
- [ ] I have added appropriate error handling
- [x] Code is optimized for performance
- [x] No sensitive information (API keys, secrets) is included

### Related Issues

- Fixes flemingvincent/expo-supabase-starter#92

### Additional Notes

None.
